### PR TITLE
WP7 hardening: auto-copyright-1 (v1.6148.2110)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ Same plugin, same `WP_Query` against `post_status=publish` to find the earliest 
 
 ## What it doesn't do
 
-- It doesn't store the calculated year — it recalculates on each render. For a high-traffic footer, the calculation is one cached `WP_Query`, so the cost is negligible.
+- It doesn't store the calculated year — it recalculates on each render. For a high-traffic footer, the earliest-post lookup is cached in a transient, so the cost is negligible.
 - It doesn't handle multi-site copyright spans across a network — single-site only.
+
+> **Block themes (FSE):** the bundled "Auto Copyright" widget is a classic `WP_Widget` and does not appear in the Site Editor on block themes (the WordPress 6.x / 7.0 default). On a block theme, use the `[auto_copyright]` shortcode (via a Shortcode block) or the `thisismyurl_autocopyright()` template tag in a footer template part. The widget is retained for classic themes.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Auto-generates a WordPress footer copyright notice spanning your first published
 
 ## The short story
 
-I wrote this plugin in 2008. In January 2016, Phill Coxon took it over and maintained it through the WordPress 4.x era. The plugin had been quiet for a while, and I've brought it back home to keep it working on modern WordPress.
+I wrote this plugin in 2008. In January 2016, Phill Coxon took it over and maintained it between 2016 and 2019. The plugin had been quiet for a while, and I've brought it back home to keep it working on modern WordPress.
 
 Same plugin, same `WP_Query` against `post_status=publish` to find the earliest post date, same year-span output, same shortcode and template-tag entry points. The maintenance is mine again.
 
@@ -93,7 +93,7 @@ This plugin is built and maintained by [This Is My URL](https://thisismyurl.com/
 
 ## License
 
-GPL-2.0-or-later — see [LICENSE](LICENSE) or [gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html). The original copyright remains with Christopher Ross (2008); maintenance contributions through 2016 are credited to Phill Coxon.
+GPL-2.0-or-later — see [LICENSE](LICENSE) or [gnu.org/licenses/gpl-2.0.html](https://www.gnu.org/licenses/gpl-2.0.html). The original copyright remains with Christopher Ross (2008); maintenance contributions between 2016 and 2019 are credited to Phill Coxon.
 
 ---
 *This project follows the [10 Core Pillars](PILLARS.md). Support quality work [here](https://github.com/sponsors/thisismyurl).*

--- a/auto-copyright-1.php
+++ b/auto-copyright-1.php
@@ -8,7 +8,7 @@
  * Version:      1.6147
  * Requires at least: 5.6
  * Requires PHP: 7.4
- * Tested up to: 6.9
+ * Tested up to: 7.0
  * License:      GPL-2.0-or-later
  * License URI:  https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain:  auto-copyright-1
@@ -52,19 +52,24 @@ defined( 'ABSPATH' ) || exit;
 		$option = \wp_parse_args( $arg, $defaults );
 
 		$format = \str_replace( '#c#', '&copy;', $option['format'] );
-		$format = \str_replace( '#y#', \get_the_date( 'Y' ), $format );
+		$format = \str_replace( '#y#', (string) \get_the_date( 'Y' ), $format );
 		$format = \str_replace( '#sitename#', \get_bloginfo( 'name' ), $format );
 
-		return $format;
+		return \wp_kses_post( $format );
 	}
 	\add_shortcode( 'thisismyurl_autocopyright_article', __NAMESPACE__ . '\thisismyurl_autocopyright_article' );
 
 	/**
-	 * Site-wide copyright notice spanning earliest published post to most recent.
+	 * Site-wide copyright notice spanning earliest published post to the current year.
 	 *
-	 * @param string|null $format_result Format string. Supports #c# #from# #to# placeholders.
+	 * `#from#` resolves to the earliest published-post year; `#to#` and `#y#` both
+	 * resolve to the current (timezone-correct) year. When the site has no published
+	 * posts, or the earliest post is from the current year, the range collapses to a
+	 * single year so the notice reads "Copyright ( © ) 2026" rather than an empty span.
+	 *
+	 * @param string|null $format_result Format string. Supports #c# #from# #to# #y# placeholders.
 	 *                                   Pass null to use the DEFAULT_FORMAT constant.
-	 * @return string Rendered notice.
+	 * @return string Rendered, escaped notice safe for echo.
 	 */
 	function thisismyurl_autocopyright( ?string $format_result = null ): string {
 		if ( null === $format_result || '' === $format_result ) {
@@ -76,11 +81,22 @@ defined( 'ABSPATH' ) || exit;
 		$to    = $years['to'];
 
 		$format_result = \str_replace( 'format=', '', $format_result );
-		$format_result = \str_replace( '#from#', $from, $format_result );
+
+		// Collapse "#from# - #to#" to a single year when there is no earlier year to
+		// span from — either the site has no published posts, or the earliest post is
+		// from the current year. This avoids "©  - 2026" and "© 2026 - 2026".
+		if ( '' === $from || $from === $to ) {
+			$format_result = \str_replace( '#from# - #to#', $to, $format_result );
+			$format_result = \str_replace( '#from#', $to, $format_result );
+		} else {
+			$format_result = \str_replace( '#from#', $from, $format_result );
+		}
+
 		$format_result = \str_replace( '#to#', $to, $format_result );
+		$format_result = \str_replace( '#y#', $to, $format_result );
 		$format_result = \str_replace( '#c#', '&copy;', $format_result );
 
-		return $format_result;
+		return \wp_kses_post( $format_result );
 	}
 
 	// -------------------------------------------------------------------------
@@ -88,65 +104,54 @@ defined( 'ABSPATH' ) || exit;
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Earliest / latest published-post years, cached in a transient.
+	 * Earliest published-post year ("from") and the current year ("to").
 	 *
-	 * Invalidated on save_post / deleted_post / trashed_post.
+	 * `from` is the year of the earliest published post, looked up once and cached
+	 * in a transient (invalidated on save_post / deleted_post / trashed_post). `to`
+	 * is always the current, timezone-correct year — computed fresh on every call so
+	 * the notice rolls over at midnight on New Year without waiting for the transient
+	 * to expire. Only `from` is cached; the year lookup is the expensive half.
 	 *
 	 * @return array{from:string,to:string}
 	 */
 	function thisismyurl_autocopyright_get_year_span(): array {
-		$cached = \get_transient( 'thisismyurl_autocopyright_year_span' );
-		if ( false !== $cached && \is_array( $cached ) ) {
-			return $cached;
+		$to = (string) \wp_date( 'Y' );
+
+		$from = \get_transient( 'thisismyurl_autocopyright_from_year' );
+		if ( false === $from ) {
+			$from       = '';
+			$from_posts = \get_posts(
+				array(
+					'post_status'      => 'publish',
+					'order'            => 'ASC',
+					'orderby'          => 'date',
+					'numberposts'      => 1,
+					'fields'           => 'ids',
+					'no_found_rows'    => true,
+					'suppress_filters' => false,
+				)
+			);
+			if ( ! empty( $from_posts ) ) {
+				$from = (string) \get_the_time( 'Y', $from_posts[0] );
+			}
+
+			\set_transient( 'thisismyurl_autocopyright_from_year', $from, \DAY_IN_SECONDS );
 		}
 
-		$from = '';
-		$to   = '';
-
-		$from_posts = \get_posts(
-			array(
-				'post_status'      => 'publish',
-				'order'            => 'ASC',
-				'orderby'          => 'date',
-				'numberposts'      => 1,
-				'fields'           => 'ids',
-				'no_found_rows'    => true,
-				'suppress_filters' => false,
-			)
-		);
-		if ( ! empty( $from_posts ) ) {
-			$from = (string) \get_the_time( 'Y', $from_posts[0] );
-		}
-
-		$to_posts = \get_posts(
-			array(
-				'post_status'      => 'publish',
-				'order'            => 'DESC',
-				'orderby'          => 'date',
-				'numberposts'      => 1,
-				'fields'           => 'ids',
-				'no_found_rows'    => true,
-				'suppress_filters' => false,
-			)
-		);
-		if ( ! empty( $to_posts ) ) {
-			$to = (string) \get_the_time( 'Y', $to_posts[0] );
-		}
-
-		$span = array(
-			'from' => $from,
+		return array(
+			'from' => (string) $from,
 			'to'   => $to,
 		);
-
-		\set_transient( 'thisismyurl_autocopyright_year_span', $span, \DAY_IN_SECONDS );
-
-		return $span;
 	}
 
 	/**
-	 * Invalidate the cached year span when posts change.
+	 * Invalidate the cached earliest-post year when posts change.
+	 *
+	 * Also clears the pre-1.6148 `_year_span` transient so upgraded sites don't
+	 * leave a stale orphan behind.
 	 */
 	function thisismyurl_autocopyright_flush_year_cache(): void {
+		\delete_transient( 'thisismyurl_autocopyright_from_year' );
 		\delete_transient( 'thisismyurl_autocopyright_year_span' );
 	}
 	\add_action( 'save_post',    __NAMESPACE__ . '\thisismyurl_autocopyright_flush_year_cache' );
@@ -232,7 +237,7 @@ defined( 'ABSPATH' ) || exit;
 				</label>
 				<br />
 				<em>
-					<a href="<?php echo \esc_url( \plugins_url( 'readme.txt', __FILE__ ) ); ?>">
+					<a href="<?php echo \esc_url( 'https://thisismyurl.com/downloads/auto-copyright-1/' ); ?>" target="_blank" rel="noopener noreferrer">
 						<?php \esc_html_e( 'Learn about format options.', 'auto-copyright-1' ); ?>
 					</a>
 				</em>
@@ -264,7 +269,8 @@ defined( 'ABSPATH' ) || exit;
 				echo $before_title . \esc_html( $title ) . $after_title; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- theme-supplied chrome.
 			}
 
-			echo \wp_kses_post( thisismyurl_autocopyright( $format ) );
+			// thisismyurl_autocopyright() returns wp_kses_post()-escaped output.
+			echo thisismyurl_autocopyright( $format ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- escaped at source.
 
 			echo isset( $args['after_widget'] ) ? $args['after_widget'] : ''; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- theme-supplied chrome.
 		}

--- a/auto-copyright-1.php
+++ b/auto-copyright-1.php
@@ -5,7 +5,7 @@
  * Description:  Automates the copyright notice for websites.
  * Author:       Christopher Ross
  * Author URI:   https://thisismyurl.com/
- * Version:      1.6147
+ * Version:      1.6148.2110
  * Requires at least: 5.6
  * Requires PHP: 7.4
  * Tested up to: 7.0

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: copyright, footer, shortcode, widget, year
 Requires at least: 5.6
 Requires PHP: 7.4
 Tested up to: 7.0
-Stable tag: 1.6147
+Stable tag: 1.6148.2110
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -14,7 +14,7 @@ Automatically generates a copyright notice based on the first and last post publ
 
 == Description ==
 
-Automatically generates a copyright notice based on the first and last post published in the WordPress database. The notice can be placed anywhere in the web site template or included as a short code within a post itself.
+Automatically generates a copyright notice based on the first and last post published in the WordPress database. The notice can be placed anywhere in the web site template or included as a shortcode within a post itself.
 
 The plugin includes the following theme functions:
 

--- a/readme.txt
+++ b/readme.txt
@@ -28,7 +28,7 @@ Format placeholders: <code>#c#</code> (©), <code>#from#</code> (the year of you
 
 The bundled "Auto Copyright" widget is a classic <code>WP_Widget</code> and is therefore legacy: it does not appear in the Site Editor on block themes (the default in WordPress 6.x and 7.0). On a block theme, place the notice with the <code>[auto_copyright]</code> shortcode (via a Shortcode block) or the <code>thisismyurl_autocopyright()</code> template tag in a footer template part. The widget is retained for classic themes only.
 
-This plugin was originally written by Christopher Ross in 2008, maintained by Phill Coxon during the WordPress 4.x era, and is now maintained again by Christopher at https://thisismyurl.com/.
+This plugin was originally written by Christopher Ross in 2008, maintained by Phill Coxon between 2016 and 2019, and is now maintained again by Christopher at https://thisismyurl.com/.
 
 == Installation ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -8,7 +8,7 @@ Requires PHP: 7.4
 Tested up to: 7.0
 Stable tag: 1.6147
 License: GPL-2.0-or-later
-License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 Automatically generates a copyright notice based on the first and last post published in the WordPress database.
 
@@ -21,6 +21,12 @@ The plugin includes the following theme functions:
 * <code>thisismyurl_autocopyright_article( 'format=#c# #y# #sitename#. All Rights Reserved.' )</code> - Will display the copyright for a specific article, must be called from within the Loop.
 
 * <code>thisismyurl_autocopyright( 'Copyright ( #c# ) #from# - #to#' )</code> - Will display the full copyright for the site
+
+Format placeholders: <code>#c#</code> (©), <code>#from#</code> (the year of your earliest published post), <code>#to#</code> and <code>#y#</code> (the current year), and <code>#sitename#</code> (your site title). When the site has no published posts, or the earliest post is from the current year, the range collapses to a single year.
+
+= Block themes (FSE) =
+
+The bundled "Auto Copyright" widget is a classic <code>WP_Widget</code> and is therefore legacy: it does not appear in the Site Editor on block themes (the default in WordPress 6.x and 7.0). On a block theme, place the notice with the <code>[auto_copyright]</code> shortcode (via a Shortcode block) or the <code>thisismyurl_autocopyright()</code> template tag in a footer template part. The widget is retained for classic themes only.
 
 This plugin was originally written by Christopher Ross in 2008, maintained by Phill Coxon during the WordPress 4.x era, and is now maintained again by Christopher at https://thisismyurl.com/.
 
@@ -47,6 +53,13 @@ You can change how the plugin functions by adding the format option to the funct
 <code>echo thisismyurl_autocopyright('format=Copyright (#c#) #from# - #to#');</code>
 
 == Change Log ==
+
+= 1.6148 =
+* Fix the core promise: #to# and #y# now resolve to the current year (timezone-correct via wp_date), matching the documentation, instead of the newest published post's year.
+* Empty/single-year sites now render a single year (e.g. "Copyright ( © ) 2026") instead of an empty or duplicated range.
+* Escape the template-tag/shortcode output path with wp_kses_post() so echo do_shortcode() and the template tags are safe by default.
+* Document the classic widget as legacy and recommend the [auto_copyright] shortcode or template tag on block themes (FSE).
+* Reconcile Tested up to (7.0) and the License URI between the plugin header and readme; point the "Learn about format options" link at the plugin page instead of the raw readme.txt.
 
 = 1.6143 =
 * First full release (class 1). The 0.6xxx line was pre-release on the `x.Yddd` scheme.

--- a/tests/test-format.php
+++ b/tests/test-format.php
@@ -9,7 +9,7 @@ class Test_Auto_Copyright_Format extends WP_UnitTestCase {
 
 	public function setUp(): void {
 		parent::setUp();
-		delete_transient( 'thisismyurl_autocopyright_year_span' );
+		delete_transient( 'thisismyurl_autocopyright_from_year' );
 	}
 
 	public function test_default_format_substitutes_copyright_symbol() {
@@ -17,8 +17,10 @@ class Test_Auto_Copyright_Format extends WP_UnitTestCase {
 		$this->assertStringContainsString( '&copy;', $out, 'Default output should contain the copyright entity.' );
 	}
 
-	public function test_custom_format_replaces_year_placeholders() {
-		$post_id = self::factory()->post->create(
+	public function test_to_placeholder_is_the_current_year_not_the_newest_post() {
+		// Earliest post is old; newest published post is also in the past. #to# must
+		// still resolve to the current year, never to the newest post's year.
+		$old = self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
 				'post_date'   => '2010-06-01 12:00:00',
@@ -27,20 +29,31 @@ class Test_Auto_Copyright_Format extends WP_UnitTestCase {
 		self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
-				'post_date'   => '2026-05-03 12:00:00',
+				'post_date'   => '2011-05-03 12:00:00',
 			)
 		);
 
 		// Bust the cache so the transient repopulates with the seeded posts.
-		delete_transient( 'thisismyurl_autocopyright_year_span' );
+		delete_transient( 'thisismyurl_autocopyright_from_year' );
 
-		$out = thisismyurl_autocopyright( '#from# - #to#' );
-		$this->assertSame( '2010 - 2026', $out );
+		$current = (string) wp_date( 'Y' );
+		$out     = thisismyurl_autocopyright( '#from# - #to#' );
+		$this->assertSame( '2010 - ' . $current, $out );
 
-		wp_delete_post( $post_id, true );
+		wp_delete_post( $old, true );
 	}
 
-	public function test_year_span_is_cached_in_transient() {
+	public function test_empty_site_renders_single_current_year() {
+		// No published posts: the range must collapse to a single current year,
+		// not render an empty "  - 2026" span.
+		delete_transient( 'thisismyurl_autocopyright_from_year' );
+
+		$current = (string) wp_date( 'Y' );
+		$out     = thisismyurl_autocopyright( '#from# - #to#' );
+		$this->assertSame( $current, $out );
+	}
+
+	public function test_from_year_is_cached_in_transient() {
 		self::factory()->post->create(
 			array(
 				'post_status' => 'publish',
@@ -48,23 +61,21 @@ class Test_Auto_Copyright_Format extends WP_UnitTestCase {
 			)
 		);
 
-		// First call populates the transient.
+		// First call populates the transient with the earliest-post year.
 		thisismyurl_autocopyright_get_year_span();
-		$cached = get_transient( 'thisismyurl_autocopyright_year_span' );
+		$cached = get_transient( 'thisismyurl_autocopyright_from_year' );
 
-		$this->assertIsArray( $cached );
-		$this->assertArrayHasKey( 'from', $cached );
-		$this->assertArrayHasKey( 'to', $cached );
+		$this->assertSame( '2015', $cached );
 	}
 
 	public function test_save_post_invalidates_year_cache() {
-		set_transient( 'thisismyurl_autocopyright_year_span', array( 'from' => '1999', 'to' => '1999' ), DAY_IN_SECONDS );
+		set_transient( 'thisismyurl_autocopyright_from_year', '1999', DAY_IN_SECONDS );
 
 		self::factory()->post->create( array( 'post_status' => 'publish' ) );
 
 		$this->assertFalse(
-			get_transient( 'thisismyurl_autocopyright_year_span' ),
-			'save_post must flush the cached year span.'
+			get_transient( 'thisismyurl_autocopyright_from_year' ),
+			'save_post must flush the cached earliest-post year.'
 		);
 	}
 


### PR DESCRIPTION
WP 7 hardening pass — auto-copyright-1.

Recommendation: **QUICK** (contained fixes — quick activation check then merge + tag).

Changes (3 commits):
- Fix P1 current-year promise + P2 escaping/FSE + P3 metadata reconciliation
- Apply gate-editor readme fixes
- Stamp release version 1.6148.2110

Audit + scorecard: clients/thisismyurl/plugin-line-hardening/HARDENING-AUDIT.md
All files php -l clean. Version stamped X.6148.2110 (Toronto).